### PR TITLE
BUG: Cannot use Shell=True When using a list with subprocess.Popen()

### DIFF
--- a/pyLAR/lra/registration.py
+++ b/pyLAR/lra/registration.py
@@ -51,11 +51,11 @@ def _execute(cmd, log_file=None):
     log.info(cmd)
     if log_file:
         tempFile = open(log_file, 'w')
-        process = subprocess.Popen(cmd, stdout=tempFile, stderr=tempFile, shell=True)
+        process = subprocess.Popen(cmd, stdout=tempFile, stderr=tempFile)
         process.wait()
         tempFile.close()
     else:
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
     if log_file:
         with open(log_file, 'r') as f:


### PR DESCRIPTION
subprocess.Popen() accepts a list of arguments or a string (command line)
as its first argument. Using a string causes problems with spaces in
filenames (problem escaping spaces). Using a list solves that issue,
but the option 'Shell=True' cannot be used. As a consequence, multiple
command lines cannot be concatenated into one command line and run
at the same time. This leads to not being able to run multiple registrations
in parallel when creating an unbiased atlas: We need to wait for the
registration result before the image can be transformed. The fact
that multple registrations cannot be run in parallel is not very limiting as
registrations can use many cores to be computed.
